### PR TITLE
Add --show-ids to the list/ls command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,10 +33,11 @@ pe+-5 test-project
     - : has # of MRs, + more than 9
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		showIDs, _ := cmd.Flags().GetBool("show-ids")
 		if inProject {
 			fmt.Println("You are currently in a PROJECT directory, nothing to list")
 		} else {
-			gitlabListing()
+			gitlabListing(showIDs)
 		}
 	},
 }
@@ -126,7 +127,7 @@ func buildStatBlock(itemType string, path string, objID int) string {
 	return sb
 }
 
-func gitlabListing() {
+func gitlabListing(showIDs bool) {
 
 	var list objects.GitListing
 
@@ -141,6 +142,7 @@ func gitlabListing() {
 		list = append(list, objects.GitListItem{
 			StatBlock: buildStatBlock("g", v.Path, v.ID),
 			Path:      v.Path,
+			ID:        v.ID,
 		})
 		// fmt.Printf("%s -> %s\n", v.Path, v.FullPath)
 	}
@@ -155,6 +157,7 @@ func gitlabListing() {
 			list = append(list, objects.GitListItem{
 				StatBlock: buildStatBlock("p", v.Path, v.ID),
 				Path:      v.Path,
+				ID:        v.ID,
 			})
 		}
 		// fmt.Printf("%s -> %s\n", v.Path, v.FullPath)
@@ -162,10 +165,10 @@ func gitlabListing() {
 
 	// output the data
 
-	fmt.Println(glDataToString(list, ""))
+	fmt.Println(glDataToString(list, "", showIDs))
 }
 
-func glDataToString(glData objects.GitListing, raw string) string {
+func glDataToString(glData objects.GitListing, raw string, showid bool) string {
 
 	switch strings.ToLower(c.OutputFormat) {
 	case "raw":
@@ -177,14 +180,15 @@ func glDataToString(glData objects.GitListing, raw string) string {
 	case "yaml":
 		return glData.ToYAML()
 	case "text", "table":
-		return glData.ToTEXT(c.NoHeaders)
+		return glData.ToTEXT(c.NoHeaders, showid)
 	default:
-		return glData.ToTEXT(c.NoHeaders)
+		return glData.ToTEXT(c.NoHeaders, showid)
 	}
 }
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().BoolP("show-ids", "i", false, "Show the associated gitlab IDs")
 }
 
 // exists returns whether the given file or directory exists or not

--- a/cmd/objects/listing.go
+++ b/cmd/objects/listing.go
@@ -3,6 +3,7 @@ package objects
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/maahsome/gron"
@@ -15,7 +16,8 @@ type GitListing []GitListItem
 
 type GitListItem struct {
 	StatBlock string `json:"stat_block"`
-	Path      string `json:"Path"`
+	Path      string `json:"path"`
+	ID        int    `json:"id"`
 }
 
 // ToJSON - Write the output as JSON
@@ -53,13 +55,17 @@ func (gl *GitListing) ToYAML() string {
 	return string(glYAML[:])
 }
 
-func (gl *GitListing) ToTEXT(noHeaders bool) string {
+func (gl *GitListing) ToTEXT(noHeaders bool, showid bool) string {
 	buf, row := new(bytes.Buffer), make([]string, 0)
 
 	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
 	if !noHeaders {
-		table.SetHeader([]string{"STAT", "PATH"})
+		if showid {
+			table.SetHeader([]string{"STAT", "PATH", "ID"})
+		} else {
+			table.SetHeader([]string{"STAT", "PATH"})
+		}
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -76,9 +82,17 @@ func (gl *GitListing) ToTEXT(noHeaders bool) string {
 
 	// for i=0; i<=len(mr); i++ {
 	for _, v := range *gl {
-		row = []string{
-			v.StatBlock,
-			v.Path,
+		if showid {
+			row = []string{
+				v.StatBlock,
+				v.Path,
+				fmt.Sprintf("%d", v.ID),
+			}
+		} else {
+			row = []string{
+				v.StatBlock,
+				v.Path,
+			}
 		}
 		table.Append(row)
 	}


### PR DESCRIPTION
## Description

Add a show-ids flag to the list/ls command

## Motivation and Context

Add an easy way to retrieve the gitlab IDs

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Add a `--show-ids`/`-i` flag to `list`/`ls` command to display the gitlab IDs of the groups/projects

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes


