### PR TITLE
Add -c to clone a project after the creation happens

### DIFF
--- a/NEW_DIRECTION.md
+++ b/NEW_DIRECTION.md
@@ -20,15 +20,16 @@ gitlab-tool config group --gitlab-host git.alteryx.com --group futurama --envvar
 # while in a top level group or sub-group
 gitlab-tool ls             # output a LS like listing, identifying GROUPS/PROJECTS
                            # this process could be in charge of mkdir for ALL groups at this level
-ge-w bender
-gc-- farnsworth
-ge+- hermes
-p--- test-project
+ge-w- bender
+gc--- farnsworth
+ge+-- hermes
+p---1 test-project
 
 -     : group or project (g/p)
  -    : exists on disk (e exists, c created)
   -   : dirty (- clean, + dirty)
    -  : has worktrees (-/w)
+    - : MRs open
 # tree from current location
 gitlab-tool tree
 

--- a/cmd/create_project.go
+++ b/cmd/create_project.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,6 +45,7 @@ Perhaps you want to override the group in which you are creating the new project
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		glGroup, _ := cmd.Flags().GetInt("group")
+		cloneAfter, _ := cmd.Flags().GetBool("clone")
 		projName, _ := cmd.Flags().GetString("name")
 		projVisibility, _ := cmd.Flags().GetString("visibility")
 
@@ -56,23 +57,28 @@ Perhaps you want to override the group in which you are creating the new project
 			glGroup = cwdGroupID
 		}
 
-		createProject(projName, projVisibility, glGroup)
+		createProject(projName, projVisibility, glGroup, cloneAfter)
 	},
 }
 
-func createProject(path string, visibility string, group int) {
+func createProject(path string, visibility string, group int, cloneAfter bool) {
 
 	newProject, err := gitClient.CreateProject(group, path, visibility)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to create project")
+	} else {
+		fmt.Printf("New project %s (%d) has been created", newProject.Path, newProject.ID)
+		if cloneAfter {
+			cloneProject(path)
+		}
 	}
-	fmt.Printf("New project %s (%d) has been created", newProject.Path, newProject.ID)
 }
 
 func init() {
 	createCmd.AddCommand(createProjectCmd)
 
 	createProjectCmd.Flags().IntP("group", "g", 0, "Specify the group to create the project in")
+	createProjectCmd.Flags().BoolP("clone", "c", false, "Clone the project directly after creation")
 	createProjectCmd.Flags().StringP("name", "n", "", "Specify the name/path of the project")
 	createProjectCmd.Flags().StringP("visibility", "v", "internal", "Specify the visibility of the project")
 	createProjectCmd.MarkFlagRequired("name")


### PR DESCRIPTION
## Description

Added a -c option to `create project` to clone the created project right after.

## Motivation and Context

Generally one does a `gitlab-toool clone` immediately after the project creation.

## Dependencies

## How Has This Been Tested?

General use

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Added a `-c` option to `create project` that will turn around and clone the new project in the current working directory

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes


