### PR TITLE
Remove the depth setting from the clone command

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -112,7 +112,7 @@ func cloneProject(name string) {
 					Username: "access_token",
 					Password: token,
 				},
-				Depth:    1,
+				// Depth:    1,
 				Progress: os.Stderr,
 			})
 			if err != nil {


### PR DESCRIPTION
## Description

Came upon a cloned repository that ended up with a single commit in the git log.  The Depth setting must have come from the examples.  

## Motivation and Context

Make it work like a normal clone command.

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

- Remove the Depth setting from the clone command, ensure entire repository of commits is cloned.

### Fixes

### Deprecated

### Removed

### Breaking Changes


