### PR TITLE
Move <bash:> definitions out to the config file

### DIFF
--- a/cmd/get_job.go
+++ b/cmd/get_job.go
@@ -10,6 +10,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type PipelineJob []struct {
@@ -151,13 +152,15 @@ func getPipelineJobs(pr int, pl int) error {
 	table.SetTablePadding("\t")
 	table.SetNoWhiteSpace(true)
 
+	bashLine := viper.GetString("bash_job")
 	for _, v := range pj {
 
 		row := []string{
 			fmt.Sprintf("%d", v.ID),
 			v.Status,
 			v.Name,
-			fmt.Sprintf("<bash:watch -n 20 \"gitlab-tool get trace -p %d -j %d | tail -n 50 | decolorize\">", v.Pipeline.ProjectID, v.ID),
+			fmt.Sprintf(bashLine, v.Pipeline.ProjectID, v.ID),
+			// fmt.Sprintf("<bash:watch -n 20 \"gitlab-tool get trace -p %d -j %d | tail -n 50 | decolorize\">", v.Pipeline.ProjectID, v.ID),
 		}
 		table.Append(row)
 	}

--- a/cmd/get_project.go
+++ b/cmd/get_project.go
@@ -11,6 +11,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type Project []struct {
@@ -351,16 +352,22 @@ func getProject(id int, user string, opts int) error {
 	table.SetTablePadding("\t")
 	table.SetNoWhiteSpace(true)
 
+	bashUserLine := viper.GetString("bash_pipeline_user")
+	bashLine := viper.GetString("bash_pipeline")
+	bashMR := viper.GetString("bash_mr")
 	for _, v := range pr {
 
 		var cmdLine string
 		var mrLine string
 		if len(user) > 0 {
-			cmdLine = fmt.Sprintf("<bash:gitlab-tool get pipeline -p %d -u %s>", v.ID, user)
+			cmdLine = fmt.Sprintf(bashUserLine, v.ID, user)
+			// cmdLine = fmt.Sprintf("<bash:gitlab-tool get pipeline -p %d -u %s>", v.ID, user)
 		} else {
-			cmdLine = fmt.Sprintf("<bash:gitlab-tool get pipeline -p %d>", v.ID)
+			cmdLine = fmt.Sprintf(bashLine, v.ID)
+			// cmdLine = fmt.Sprintf("<bash:gitlab-tool get pipeline -p %d>", v.ID)
 		}
-		mrLine = fmt.Sprintf("<bash:gitlab-tool get mr -p %d>", v.ID)
+		mrLine = fmt.Sprintf(bashMR, v.ID)
+		// mrLine = fmt.Sprintf("<bash:gitlab-tool get mr -p %d>", v.ID)
 
 		row := []string{}
 		switch opts {

--- a/cmd/objects/mr.go
+++ b/cmd/objects/mr.go
@@ -10,6 +10,7 @@ import (
 	"github.com/maahsome/gron"
 	"github.com/olekukonko/tablewriter"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -203,6 +204,7 @@ func (mr *MergeRequest) ToTEXT(noHeaders bool) string {
 	table.SetTablePadding("\t") // pad with tabs
 	table.SetNoWhiteSpace(true)
 
+	bashLine := viper.GetString("bash_mr_diff")
 	// for i=0; i<=len(mr); i++ {
 	for _, v := range *mr {
 		row = []string{
@@ -211,7 +213,8 @@ func (mr *MergeRequest) ToTEXT(noHeaders bool) string {
 			v.State,
 			v.Author.Name,
 			v.CreatedAt.Format("2006-01-02 15:04:05"),
-			fmt.Sprintf("<bash:gitlab-tool get diff -p %d -m %d>", v.ProjectID, v.Iid),
+			fmt.Sprintf(bashLine, v.ProjectID, v.Iid),
+			// fmt.Sprintf("<bash:gitlab-tool get diff -p %d -m %d>", v.ProjectID, v.Iid),
 		}
 		table.Append(row)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -237,9 +237,24 @@ func initConfig() {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		logrus.Warn("Failed to read viper config file.")
+	} else {
+	checkAndUpdateConfig("bash_pipeline_user", `<bash:gitlab-tool get pipeline -p %d -u %s>`)
+	checkAndUpdateConfig("bash_pipeline", `<bash:gitlab-tool get pipeline -p %d>`)
+	checkAndUpdateConfig("bash_mr", `<bash:gitlab-tool get mr -p %d>`)
+	checkAndUpdateConfig("bash_mr_diff", `<bash:gitlab-tool get diff -p %d -m %d>`)
+	checkAndUpdateConfig("bash_job", `<bash:gitlab-tool get trace -p %d -j %d | tail -n 50>`)
+	if err := viper.WriteConfig(); err != nil {
+		logrus.WithError(err).Error("Error writing default config entries")
 	}
 }
+}
 
+func checkAndUpdateConfig(name string, value string) {
+	test := viper.GetString(name)
+	if len(test) == 0 {
+		viper.Set(name, value)
+	}
+}
 func createRestrictedConfigFile(fileName string) {
 	if _, err := os.Stat(fileName); err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Description

Move the <bash:> generated links out to the config.yaml file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

- Instead of hard coded `<bash:>` smartlinks, move the definitions out to the config.yaml file

### Fixes

### Deprecated

### Removed

### Breaking Changes


